### PR TITLE
simplify installation without optional deps when using venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__
 results/
 experiment_outputs/
 simulation_results/
+.venv

--- a/execution/worker.py
+++ b/execution/worker.py
@@ -10,7 +10,7 @@ import importlib
 from typing import Dict, Any, Tuple, List
 
 from core.simulation import Simulation
-from services.llm import ProcessIsolatedLLMService
+
 
 def _import_class(class_path: str):
     """Dynamically imports a class from a string path."""
@@ -39,6 +39,9 @@ def run_simulation_task(params: Dict[str, Any]) -> Tuple[pd.DataFrame, Dict[str,
         # 2. Instantiate LLM Service if needed
         llm_service = None
         if params['environment_params'].get('llm_model'):
+            # requests is optional package to install only when using LLMs,
+            # and it cannot be imported if not installed => dynamical import of services.llm
+            from services.llm import ProcessIsolatedLLMService
             llm_service = ProcessIsolatedLLMService(model=params['environment_params']['llm_model'])
 
         # 3. Instantiate Agent Population


### PR DESCRIPTION
* make an optional depencency optional also in the code
* remove examples that don't exist any more
=> hopefully it might simplify future onboarding 🤞 
```python
python -m venv .venv;
source .venv/bin/activate;
pip install -r requirements.txt;
awk '/^```python$/,/^```$/ {if (!/^```/) print}' Start_Here.md > start_here.py;
python -m start_here.py;
```
..still not running out of the box, but `TypeError: JAX encountered invalid PRNG key data: expected key_data to have ndim, shape, and dtype attributes. Got 0` sounds like it requires domain expertise to continue onboarding => https://discord.com/channels/1337412428773720265/1416107942280826930/1428335586623619072